### PR TITLE
Fix rendering of large fonts

### DIFF
--- a/src/bdf2fontx.c
+++ b/src/bdf2fontx.c
@@ -120,7 +120,10 @@ void bdfheader(char *name, int *width, int *height, int *type, int *sjis)
             } else {
                 *type = 0;
             }
-            break;
+        }
+
+        if (match(s, "FONTBOUNDINGBOX") == 0) {
+            sscanf(s, "FONTBOUNDINGBOX %*d %d %*d %*d", height);
         }
     }
 }

--- a/src/fontx2png.c
+++ b/src/fontx2png.c
@@ -214,7 +214,7 @@ int main(int argc, char **argv)
             }
             for (uint8_t y = 0; y < glyph.height; y++) {
                 for (uint8_t x = 0; x < glyph.width; x++) {
-                    uint8_t set = *(glyph.buffer) & (0x80 >> (x % 8));
+                    uint8_t set = *(glyph.buffer + x / 8) & (0x80 >> (x % 8));
                     if (set) {
                         gdImageSetPixel(img, x0 + x, y0 + y, color);
                     }


### PR DESCRIPTION
Hi !

Not sure it's the right place to submit a PR.

What does it do ?

I've noticed that fonts larger than 8 pixels were messed up. During my investigation I noticed two issues :

- bdf font height is badly "scanned", I implemented a quick fix to get it from the `FONTBOUNDINGBOX` bdf property which seems more logical and is more accurate than extracting it from the `FONT` bdf property. Indeed the height extracted from the `FONT` prop looks like it's more a "point size" of the font which is not always the real font height in pixel.

- `fontx2png` tool does not handle fonts larger than 8 pixel : it only reads the first 8 pixels of each character pixel line. I made a quick fix also.
